### PR TITLE
add support for reporter-wide global dimensions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,4 +169,3 @@ idea {
 task createWrapper(type: Wrapper) {
     gradleVersion = '1.8'
 }
-

--- a/src/test/java/com/blacklocus/metrics/CloudWatchReporterTest.java
+++ b/src/test/java/com/blacklocus/metrics/CloudWatchReporterTest.java
@@ -48,7 +48,9 @@ public class CloudWatchReporterTest {
                         metricRegistry,
                         CloudWatchReporterTest.class.getSimpleName(),
                         new AmazonCloudWatchAsyncClient()
-                ).start(1, TimeUnit.MINUTES);
+                )
+                        .withDimensions("unit=test group=first")
+                        .start(1, TimeUnit.MINUTES);
 
                 metricRegistry.register("TheGauge", new Gauge<Long>() {
                     @Override
@@ -87,7 +89,9 @@ public class CloudWatchReporterTest {
                         metricRegistry,
                         CloudWatchReporterTest.class.getSimpleName(),
                         new AmazonCloudWatchAsyncClient()
-                ).start(1, TimeUnit.MINUTES);
+                )
+                        .withDimensions("unit=test group=second")
+                        .start(1, TimeUnit.MINUTES);
 
                 metricRegistry.register("TheGauge", new Gauge<Long>() {
                     @Override


### PR DESCRIPTION
This pull request adds support for a reporter-wide global dimensions. Use case: in the cloud you may want to create instance-id, vpc-id, name tag dimensions and append them directly to the reporter.

Also, this is very useful if you want to integrate existing metrics (code hale JVM, Hikari, etc) and you don't have control over the names of the metrics.

A similar pull request has been created for the original library: https://github.com/blacklocus/metrics-cloudwatch
